### PR TITLE
マイページ追加実装(一覧ページへの遷移)

### DIFF
--- a/app/assets/stylesheets/users/posts_favorites.css
+++ b/app/assets/stylesheets/users/posts_favorites.css
@@ -1,0 +1,29 @@
+.mypage-user-plays {
+  width: 100%;
+  padding: 20vh 0 10vh 0;
+}
+
+/* .mypage-user-favorite-plays {
+  width: 100%;
+  padding: 20vh 0 10vh 0;
+} */
+
+.return-box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.return-btn {
+  font-size: 2vh;
+  font-weight: bold;
+  color: black;
+  background-color: #EFEFEE;
+  border-radius: 10px;
+  padding: 8px;
+}
+
+.return-btn:hover {
+  background-color: #7FDA58;
+  transition: 0.5s;
+}

--- a/app/assets/stylesheets/users/show.css
+++ b/app/assets/stylesheets/users/show.css
@@ -209,3 +209,25 @@
   border-bottom: 3px solid #EEEEEE;
 }
 /* レーダーチャート */
+
+/* もっと見るボタン(自分の投稿、お気に入り兼用) */
+.more-box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.more-btn {
+  font-size: 2vh;
+  font-weight: bold;
+  color: black;
+  background-color: #EFEFEE;
+  border-radius: 10px;
+  padding: 8px;
+}
+
+.more-btn:hover {
+  background-color: #7FDA58;
+  transition: 0.5s;
+}
+/* もっと見るボタン(自分の投稿、お気に入り兼用) */

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!, only: :show
-  before_action :find_params, only: :show
+  before_action :authenticate_user!, only: [:show, :posts, :favorites]
+  before_action :find_params, only: [:show, :posts, :favorites]
 
   def show
     if current_user.id == @user.id
@@ -12,6 +12,22 @@ class UsersController < ApplicationController
     @achivement_plays_count = @achivement_plays.joins(:play).group(:play_category_id).count
     @month_record = @achivement_plays.where(created_at: Time.now.ago(5.month).beginning_of_month..Time.now.end_of_month).group("YEAR(created_at)").group("MONTH(created_at)").count
     achivement_plays_monthly
+    else
+      redirect_to root_path
+    end
+  end
+
+  def posts
+    if current_user.id == @user.id
+      @plays = @user.plays.all.order('created_at DESC')
+    else
+      redirect_to root_path
+    end
+  end
+
+  def favorites
+    if current_user.id == @user.id
+      @favorite_plays = @user.favorite_plays.all.order('created_at DESC')
     else
       redirect_to root_path
     end

--- a/app/views/users/favorites.html.erb
+++ b/app/views/users/favorites.html.erb
@@ -1,0 +1,33 @@
+<%= render "shared/header" %>
+<div class="user-show">
+  <div class="user-box">
+    <%# お気に入り %>
+    <div class="mypage-user-plays">
+      <h2 class="user-favorite-title">お気に入り</h2>
+      <ul class="play-lists">
+        <% @favorite_plays.each do |favorite_play| %>
+          <li class="list">
+            <%= link_to play_path(favorite_play.play_id) do %>
+              <div class='play-img-content'>
+                <%= image_tag Play.find(favorite_play.play_id).image, class: "play-img" %>
+              </div>
+              <div class='play-info'>
+                <h3 class='play-name'>
+                  <%= Play.find(favorite_play.play_id).play_name %>
+                </h3>
+                <div clas='play-how'>
+                  <%= Play.find(favorite_play.play_id).how_to_play.truncate(50) %>
+                </div>
+              </div>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+      <div class="return-box">
+        <%= link_to "戻る", user_path(current_user.id), class:"return-btn" %>
+      </div>
+    </div>
+    <%# お気に入り %>
+  </div>
+</div>
+<%= render "shared/footer" %>

--- a/app/views/users/posts.html.erb
+++ b/app/views/users/posts.html.erb
@@ -1,0 +1,33 @@
+<%= render "shared/header" %>
+<div class="user-show">
+  <div class="user-box">
+    <%# 自分の投稿 %>
+    <div class="mypage-user-plays">
+      <h2 class="user-post-title">自分の投稿</h2>
+      <ul class="play-lists">
+        <% @plays.each do |play| %>
+          <li class="list">
+            <%= link_to play_path(play.id) do %>
+              <div class="play-img-content">
+                <%= image_tag play.image, class:"play-img" %>
+              </div>
+              <div class='play-info'>
+                <h3 class='play-name'>
+                  <%= play.play_name %>
+                </h3>
+                <div class='play-how'>
+                  <%= play.how_to_play.truncate(50) %>
+                </div>
+              </div>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+      <div class="return-box">
+        <%= link_to "戻る", user_path(current_user.id), class:"return-btn" %>
+      </div>
+    </div>
+    <%# 自分の投稿 %>
+  </div>
+</div>
+<%= render "shared/footer" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -61,6 +61,9 @@
           </li>
         <% end %>
       </ul>
+      <div class="more-box">
+        <%= link_to "もっと見る", posts_user_path(current_user.id), class:"more-btn" %>
+      </div>
     </div>
     <%# 自分の投稿 %>
     <%# お気に入り %>
@@ -85,6 +88,9 @@
           </li>
         <% end %>
       </ul>
+      <div class="more-box">
+        <%= link_to "もっと見る", favorites_user_path(current_user.id), class:"more-btn" %>
+      </div>
     </div>
     <%# お気に入り %>
     <%# 実績 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,5 +21,10 @@ Rails.application.routes.draw do
       get 'others'
     end
   end
-  resources :users, only: :show
+  resources :users, only: :show do
+    member do
+      get 'posts'
+      get 'favorites'
+    end
+  end
 end


### PR DESCRIPTION
# What
マイページから、ユーザーの「自分の投稿」と「お気に入り」一覧ページへ遷移させる実装を実施。

# Why
ユーザーのこれまでの全ての「自分の投稿」と「お気に入り」を閲覧できるようにする為。